### PR TITLE
Add support for volatile functions

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ jspm_packages
 # Optional npm cache directory
 .npm
 
+# Optional direnv cache directory
+.direnv
+
 # Optional REPL history
 .node_repl_history
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1723827930,
+        "narHash": "sha256-EU+W5F6y2CVNxGrGIMpY7nSVYq72WRChYxF4zpjx0y4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d4a7a4d0e066278bfb0d77bd2a7adde1c0ec9e3d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "Development environment";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      inherit (nixpkgs) lib;
+
+      systems = [
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+
+      eachSystem = lib.flip lib.mapAttrs (
+        lib.genAttrs systems (system: nixpkgs.legacyPackages.${system})
+      );
+    in
+    {
+      devShell = eachSystem (
+        system: pkgs:
+        pkgs.mkShell {
+          packages = [
+            pkgs.nodejs
+            pkgs.pnpm_9
+          ];
+        }
+      );
+    };
+}

--- a/src/volatile.ts
+++ b/src/volatile.ts
@@ -1,4 +1,16 @@
-import {REACTIVE_NODE, type ReactiveNode, producerAccessed} from './graph';
+import {
+  REACTIVE_NODE,
+  type ReactiveNode,
+  producerAccessed,
+  producerIncrementEpoch,
+  producerNotifyConsumers,
+} from './graph';
+
+/**
+ * A dedicated symbol used before a computed value has been calculated for the first time.
+ * Explicitly typed as `any` so we can use it as signal's value.
+ */
+export const UNSET = /* @__PURE__ */ Symbol('UNSET');
 
 /**
  * Volatile functions read from external sources. They can change at any time
@@ -9,8 +21,15 @@ import {REACTIVE_NODE, type ReactiveNode, producerAccessed} from './graph';
  * it's stale and bust the cache of everything downstream.
  */
 export function createVolatile<T>(getSnapshot: () => T): VolatileNode<T> {
-  const node: VolatileNode<T> = Object.create(REACTIVE_NODE);
+  const node: VolatileNode<T> = Object.create(VOLATILE_NODE);
   node.getSnapshot = getSnapshot;
+
+  node.onChange = () => {
+    node.value = UNSET;
+    node.version++;
+    producerIncrementEpoch();
+    producerNotifyConsumers(node);
+  };
 
   return node;
 }
@@ -19,14 +38,43 @@ export function volatileGetFn<T>(this: VolatileNode<T>): T {
   producerAccessed(this);
 
   // TODO:
-  // - Cache when live.
   // - Handle errors in live snapshots.
   // - Throw if dependencies are used in the snapshot.
   // - Bust downstream caches when not live.
+
+  if (this.live) {
+    if (this.value === UNSET) {
+      this.value = this.getSnapshot();
+    }
+
+    return this.value;
+  }
+
   return this.getSnapshot();
 }
 
 export interface VolatileNode<T> extends ReactiveNode {
   /** Read state from the outside world. May be expensive. */
   getSnapshot: () => T;
+
+  /** Called by the `subscribe` handler. Invalidates the cached value. */
+  onChange(): void;
+
+  /** Whether the volatile node is being observed. */
+  live: boolean;
+
+  /**
+   * Cached value. Only used when being watched and a subscriber is provided.
+   * Otherwise values are pulled from `getSnapshot`.
+   */
+  value: typeof UNSET | T;
 }
+
+// Note: Using an IIFE here to ensure that the spread assignment is not considered
+// a side-effect, ending up preserving `VOLATILE_NODE` and `REACTIVE_NODE`.
+// TODO: remove when https://github.com/evanw/esbuild/issues/3392 is resolved.
+const VOLATILE_NODE = /* @__PURE__ */ (() => ({
+  ...REACTIVE_NODE,
+  value: UNSET,
+  live: false,
+}))();

--- a/src/volatile.ts
+++ b/src/volatile.ts
@@ -1,0 +1,32 @@
+import {REACTIVE_NODE, type ReactiveNode, producerAccessed} from './graph';
+
+/**
+ * Volatile functions read from external sources. They can change at any time
+ * without notifying the graph. If the source supports it, optionally we can
+ * subscribe to changes while observed.
+ *
+ * Unless the external source is actively being observed, we have to assume
+ * it's stale and bust the cache of everything downstream.
+ */
+export function createVolatile<T>(getSnapshot: () => T): VolatileNode<T> {
+  const node: VolatileNode<T> = Object.create(REACTIVE_NODE);
+  node.getSnapshot = getSnapshot;
+
+  return node;
+}
+
+export function volatileGetFn<T>(this: VolatileNode<T>): T {
+  producerAccessed(this);
+
+  // TODO:
+  // - Cache when live.
+  // - Handle errors in live snapshots.
+  // - Throw if dependencies are used in the snapshot.
+  // - Bust downstream caches when not live.
+  return this.getSnapshot();
+}
+
+export interface VolatileNode<T> extends ReactiveNode {
+  /** Read state from the outside world. May be expensive. */
+  getSnapshot: () => T;
+}

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -153,12 +153,23 @@ export namespace Signal {
       const node = this[NODE];
       node.value = VOLATILE_UNSET;
       node.volatile = false;
-      node.unsubscribe = node.subscribe?.(node.onChange);
+
+      let unsubscribed = false;
+      const unsubscribe = node.subscribe?.call(this, () => {
+        if (!unsubscribed) {
+          node.onChange.call(node);
+        }
+      });
+
+      node.unsubscribe = () => {
+        unsubscribed = true;
+        unsubscribe?.call(this);
+      };
     }
 
     #unwatched() {
       const node = this[NODE];
-      node.unsubscribe?.();
+      node.unsubscribe();
       node.volatile = true;
     }
   }

--- a/tests/Signal/volatile.test.ts
+++ b/tests/Signal/volatile.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 import {Signal} from '../../src/wrapper.js';
 
 describe('Signal.Volatile', () => {
@@ -6,5 +6,70 @@ describe('Signal.Volatile', () => {
     const volatile = new Signal.Volatile(() => 'value');
 
     expect(volatile.get()).toBe('value');
+  });
+
+  it('always reads values from source when not observed', () => {
+    const spy = vi.fn(() => 'value');
+    const volatile = new Signal.Volatile(spy);
+
+    expect(spy).not.toHaveBeenCalled();
+
+    volatile.get();
+    volatile.get();
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls the subscribe function when observed', () => {
+    const unsubscribe = vi.fn();
+    const subscribe = vi.fn(() => unsubscribe);
+    const volatile = new Signal.Volatile(() => 'value', {
+      subscribe,
+    });
+
+    expect(subscribe).not.toHaveBeenCalled();
+    const watcher = new Signal.subtle.Watcher(() => {});
+    watcher.watch(volatile);
+
+    expect(subscribe).toHaveBeenCalled();
+  });
+
+  it('unsubscribes when the function is no longer observed', () => {
+    const unsubscribe = vi.fn();
+    const volatile = new Signal.Volatile(() => 'value', {
+      subscribe: () => unsubscribe,
+    });
+
+    const watcher = new Signal.subtle.Watcher(() => {});
+    watcher.watch(volatile);
+    expect(unsubscribe).not.toHaveBeenCalled();
+
+    watcher.unwatch(volatile);
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it('survives subscribe without an unsubscribe callback', () => {
+    const volatile = new Signal.Volatile(() => 'value', {
+      subscribe: () => {},
+    });
+
+    const watcher = new Signal.subtle.Watcher(() => {});
+    watcher.watch(volatile);
+    const pass = () => watcher.unwatch(volatile);
+
+    expect(pass).not.toThrow();
+  });
+
+  it('returns the cached value when observed', () => {
+    const getSnapshot = vi.fn(() => 'value');
+    const volatile = new Signal.Volatile(getSnapshot, {
+      subscribe: () => {},
+    });
+
+    const watcher = new Signal.subtle.Watcher(() => {});
+    watcher.watch(volatile);
+
+    expect(volatile.get()).toBe('value');
+    expect(volatile.get()).toBe('value');
+    expect(getSnapshot).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/Signal/volatile.test.ts
+++ b/tests/Signal/volatile.test.ts
@@ -1,0 +1,10 @@
+import {describe, expect, it} from 'vitest';
+import {Signal} from '../../src/wrapper.js';
+
+describe('Signal.Volatile', () => {
+  it('reads the value using the given function', () => {
+    const volatile = new Signal.Volatile(() => 'value');
+
+    expect(volatile.get()).toBe('value');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.*'],
+  },
+});


### PR DESCRIPTION
An experiment in adding "volatile" functions to the TC39 Signals proposal.

```ts
const mediaQuery = window.matchMedia('(min-width: 1200px)')

const $matches = new Signal.Volatile(
  () => mediaQuery.matches,
  (onChange) => {
    mediaQuery.onchange = onChange

    return () => {
      mediaQuery.onchange = null
    }
  },
)
```

This signal reads from source when not observed, but runs in producer/consumer mode when held by an effect.

See [the proposal](https://github.com/tc39/proposal-signals/issues/237) for reasoning and mechanics.